### PR TITLE
Remove non-breaking spaces from xml

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,45 +1,49 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
-       <system>
-           <tab id="CreditClick_PriceModule_tab" translate="label" sortOrder="10">
-               <label>CreditClick</label>
-           </tab>
-           <section id="creditclick_pricemodule" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-               <class>separator-top</class>
-               <label>Price Module settings</label>
-               <tab>CreditClick_PriceModule_tab</tab>
-               <resource>CreditClick_PriceModule::settings</resource>
-               <group id="general" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
-                   <label>CreditClick Price Module settings</label>
-                   <field id="enable_catalog_category" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                       <label>Enable on Catalog Category overview</label>
-                       <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                   </field>
-                   <field id="enable_catalog_product" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                       <label>Enable on Catalog Product detail</label>
-                       <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                   </field>
+    <system>
+        <tab id="CreditClick_PriceModule_tab" translate="label" sortOrder="10">
+            <label>CreditClick</label>
+        </tab>
 
-                   <field id="enable_catalogsearch_result" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                       <label>Enable on Catalogsearch result</label>
-                       <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                   </field>
+        <section id="creditclick_pricemodule" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <class>separator-top</class>
+            <label>Price Module settings</label>
+            <tab>CreditClick_PriceModule_tab</tab>
+            <resource>CreditClick_PriceModule::settings</resource>
+            <group id="general" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>CreditClick Price Module settings</label>
 
-                   <field id="enable_checkout_cart" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                       <label>Enable on Checkout Cart</label>
-                       <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                   </field>
+                <field id="enable_catalog_category" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable on Catalog Category overview</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
 
-                   <field id="country" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                       <label>Country</label>
-                        <source_model>CreditClick\PriceModule\Model\Config\Source\Country</source_model>                      
-                        <comment>Choose country in which you offer the loan</comment>
-                   </field>
-                   <field id="custom_css" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                       <label>Custom Css</label>
-                       <comment>Add custom styles (CSS). use classname .cc-wrapper</comment>
-                   </field>
-               </group>
-           </section>
-       </system>
+                <field id="enable_catalog_product" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable on Catalog Product detail</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+
+                <field id="enable_catalogsearch_result" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable on Catalogsearch result</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+
+                <field id="enable_checkout_cart" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable on Checkout Cart</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+
+                <field id="country" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Country</label>
+                    <source_model>CreditClick\PriceModule\Model\Config\Source\Country</source_model>
+                    <comment>Choose country in which you offer the loan</comment>
+                </field>
+
+                <field id="custom_css" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Custom Css</label>
+                    <comment>Add custom styles (CSS). use classname .cc-wrapper</comment>
+                </field>
+            </group>
+        </section>
+    </system>
 </config>


### PR DESCRIPTION
```
The XML in file "vendor/creditclick/price_module/etc/adminhtml/system.xml" is invalid:
Element 'config': Character content other than whitespace is not allowed because the content type is 'element-only'.
```

This is because the file is filled with a bunch of non-breaking spaces. This PR resolves that issue and assures the xml can be parsed correctly.